### PR TITLE
ci: switch create-github-app-token to client-id

### DIFF
--- a/.github/actions/build-context/action.yaml
+++ b/.github/actions/build-context/action.yaml
@@ -25,8 +25,8 @@ inputs:
     description: "Platform: studio or cloud"
     required: false
     default: "studio"
-  ovmlayer_app_id:
-    description: "GitHub App ID for downloading ovmlayer from private repo"
+  ovmlayer_app_client_id:
+    description: "GitHub App Client ID for downloading ovmlayer from private repo"
     required: true
   ovmlayer_app_private_key:
     description: "GitHub App Private Key for downloading ovmlayer"
@@ -57,5 +57,5 @@ runs:
         ovmlayer: ${{ inputs.ovmlayer }}
         rootfs: ${{ inputs.rootfs }}
         platform: ${{ inputs.platform }}
-        ovmlayer_app_id: ${{ inputs.ovmlayer_app_id }}
+        ovmlayer_app_client_id: ${{ inputs.ovmlayer_app_client_id }}
         ovmlayer_app_private_key: ${{ inputs.ovmlayer_app_private_key }}

--- a/.github/actions/fetch/action.yaml
+++ b/.github/actions/fetch/action.yaml
@@ -27,8 +27,8 @@ inputs:
     description: "Platform: studio or cloud"
     required: false
     default: "studio"
-  ovmlayer_app_id:
-    description: "GitHub App ID for downloading ovmlayer from private repo"
+  ovmlayer_app_client_id:
+    description: "GitHub App Client ID for downloading ovmlayer from private repo"
     required: true
   ovmlayer_app_private_key:
     description: "GitHub App Private Key for downloading ovmlayer"
@@ -60,7 +60,7 @@ runs:
       id: ovmlayer-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.ovmlayer_app_id }}
+        client-id: ${{ inputs.ovmlayer_app_client_id }}
         private-key: ${{ inputs.ovmlayer_app_private_key }}
         owner: oomol
         repositories: ovmlayer,ovmlayer-next

--- a/.github/actions/setup-ovmlayer-runner/action.yaml
+++ b/.github/actions/setup-ovmlayer-runner/action.yaml
@@ -25,8 +25,8 @@ inputs:
     description: "Platform for downloading releases. Defaults to studio, can be studio or cloud"
     required: false
     default: "studio"
-  ovmlayer_app_id:
-    description: "GitHub App ID for downloading ovmlayer from private repo"
+  ovmlayer_app_client_id:
+    description: "GitHub App Client ID for downloading ovmlayer from private repo"
     required: true
   ovmlayer_app_private_key:
     description: "GitHub App Private Key for downloading ovmlayer"
@@ -57,7 +57,7 @@ runs:
         ovmlayer: ${{ inputs.ovmlayer }}
         rootfs: ${{ inputs.rootfs }}
         platform: ${{ inputs.platform }}
-        ovmlayer_app_id: ${{ inputs.ovmlayer_app_id }}
+        ovmlayer_app_client_id: ${{ inputs.ovmlayer_app_client_id }}
         ovmlayer_app_private_key: ${{ inputs.ovmlayer_app_private_key }}
 
     - name: Install binaries to system paths

--- a/.github/workflows/image-oocana-runtime.yml
+++ b/.github/workflows/image-oocana-runtime.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           architecture: arm64
-          ovmlayer_app_id: ${{ vars.OOMOL_DOWNLOADER_APP_ID }}
+          ovmlayer_app_client_id: ${{ vars.OOMOL_DOWNLOADER_APP_CLIENT_ID }}
           ovmlayer_app_private_key: ${{ secrets.OOMOL_DOWNLOADER_APP_PRIVATE_KEY }}
       - name: Download executor layer (arm64)
         shell: bash
@@ -86,7 +86,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           architecture: amd64
-          ovmlayer_app_id: ${{ vars.OOMOL_DOWNLOADER_APP_ID }}
+          ovmlayer_app_client_id: ${{ vars.OOMOL_DOWNLOADER_APP_CLIENT_ID }}
           ovmlayer_app_private_key: ${{ secrets.OOMOL_DOWNLOADER_APP_PRIVATE_KEY }}
       - name: Download executor layer (amd64)
         shell: bash

--- a/.github/workflows/layer-cloud-executor.yml
+++ b/.github/workflows/layer-cloud-executor.yml
@@ -26,7 +26,7 @@ jobs:
           architecture: ${{ steps.arch.outputs.arch }}
           ovmlayer: v0.6.7
           platform: "cloud"
-          ovmlayer_app_id: ${{ vars.OOMOL_DOWNLOADER_APP_ID }}
+          ovmlayer_app_client_id: ${{ vars.OOMOL_DOWNLOADER_APP_CLIENT_ID }}
           ovmlayer_app_private_key: ${{ secrets.OOMOL_DOWNLOADER_APP_PRIVATE_KEY }}
       - name: create layer
         run: |

--- a/.github/workflows/layer-executor.yml
+++ b/.github/workflows/layer-executor.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           token: ${{ github.token }}
           architecture: ${{ steps.arch.outputs.arch }}
-          ovmlayer_app_id: ${{ vars.OOMOL_DOWNLOADER_APP_ID }}
+          ovmlayer_app_client_id: ${{ vars.OOMOL_DOWNLOADER_APP_CLIENT_ID }}
           ovmlayer_app_private_key: ${{ secrets.OOMOL_DOWNLOADER_APP_PRIVATE_KEY }}
       - name: create layer
         run: |

--- a/.github/workflows/tag-executor-layer.yml
+++ b/.github/workflows/tag-executor-layer.yml
@@ -25,7 +25,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OOMOL_DOWNLOADER_APP_ID }}
+          client-id: ${{ vars.OOMOL_DOWNLOADER_APP_CLIENT_ID }}
           private-key: ${{ secrets.OOMOL_DOWNLOADER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}

--- a/.github/workflows/tag-server-base.yml
+++ b/.github/workflows/tag-server-base.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OOMOL_DOWNLOADER_APP_ID }}
+          client-id: ${{ vars.OOMOL_DOWNLOADER_APP_CLIENT_ID }}
           private-key: ${{ secrets.OOMOL_DOWNLOADER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 
 ### `.github/actions/fetch`
 - Purpose: download `oocana`, `ovmlayer`, and `rootfs.tar` into a target directory
-- Required inputs: `architecture`, `destination`, `ovmlayer_app_id`, `ovmlayer_app_private_key`
+- Required inputs: `architecture`, `destination`, `ovmlayer_app_client_id`, `ovmlayer_app_private_key`
 - Optional inputs: `token`, `oocana`, `ovmlayer`, `rootfs`, `platform`
 - Outputs: `oocana_version`, `ovmlayer_version`, `rootfs_version`
 - Notes: `platform=cloud` pulls `ovmlayer` from `oomol/ovmlayer-next`; otherwise it uses `oomol/ovmlayer`
@@ -24,12 +24,12 @@
 
 ### `.github/actions/setup-ovmlayer-runner`
 - Purpose: install `oocana` and `ovmlayer` onto the GitHub Actions runner, then set up a rootfs overlay
-- Required inputs: `architecture`, `ovmlayer_app_id`, `ovmlayer_app_private_key`
+- Required inputs: `architecture`, `ovmlayer_app_client_id`, `ovmlayer_app_private_key`
 - Optional inputs: `token`, `oocana`, `ovmlayer`, `rootfs`, `platform`
 - Outputs: `oocana_version`, `ovmlayer_version`, `rootfs_version`
 - Notes: `platform=studio` runs `ovmlayer setup dev`; `platform=cloud` runs `ovmlayer setup` with a writable overlay
 
 ## Required GitHub Configuration
 
-- Repository variable: `OOMOL_DOWNLOADER_APP_ID`
+- Repository variable: `OOMOL_DOWNLOADER_APP_CLIENT_ID`
 - Repository secret: `OOMOL_DOWNLOADER_APP_PRIVATE_KEY`


### PR DESCRIPTION
`actions/create-github-app-token` 自 v3.1.0 起弃用 `app-id` 输入并改用 `client-id`，每次运行都会打印 "Input 'app-id' has been deprecated" 告警。本 PR 改为传组织级变量 `OOMOL_DOWNLOADER_APP_CLIENT_ID`（已配置，所有仓库可见），三个 composite action 的输入 `ovmlayer_app_id` 相应改名为 `ovmlayer_app_client_id`。这些 action 只在本仓库内部引用（已全组织搜索确认），调用处与 _AGENTS.md_ 已同步更新。
